### PR TITLE
"CorsOptions" texts changed to "CorsPolicy"

### DIFF
--- a/docs/configuration/cors.md
+++ b/docs/configuration/cors.md
@@ -32,9 +32,9 @@ idsrvOptions.CorsPolicy.PolicyCallback = async origin =>
 };
 ```
 
-#### CorsOptions.AllowAll
+#### CorsPolicy.AllowAll
 
-For convenience there is a static property `CorsOptions.AllowAll` that will allow all origins. This is useful for debugging or development.
+For convenience there is a static property `CorsPolicy.AllowAll` that will allow all origins. This is useful for debugging or development.
 
 ```csharp
 var idsvrOptions = new IdentityServerOptions {


### PR DESCRIPTION
As "CorsOptions" is changed to CorsPolicy in the latest releases.
Changed the title line 35 and the quoted text in line 37.