### PR TITLE
[Authorize] looks required in WebAPI Controller

### DIFF
--- a/docs/overview/simplestOAuth.md
+++ b/docs/overview/simplestOAuth.md
@@ -155,6 +155,7 @@ install-package Thinktecture.IdentityServer3.AccessTokenValidation
 Add this simple test controller:
 
 ```csharp
+[Authorize]
 [Route("test")]
 public class TestController : ApiController
 {


### PR DESCRIPTION
Hey guys, sorry by interrupt but in WebAPI simplest project snippet you should use [Authorize] Datanotation if you wanna restrict the access to this controller generating 401 for unauthorized http calls. Thanks and congrats! IdSrv3 its an amazing work, i just lovin it!