### PR TITLE
Update logging.md

### DIFF
--- a/docs/configuration/logging.md
+++ b/docs/configuration/logging.md
@@ -41,6 +41,8 @@ The `LoggingOptions` class has the following settings:
 Add the following snippet to your configuration file to funnel all logging messages to a simple text file.
 We use [Baretail](https://www.baremetalsoft.com/baretail/) for viewing the log files.
 
+**Note:** If you use this method you need to ensure that the account running the application pool has write access to the application directory.
+
 ```xml
 <system.diagnostics>
   <trace autoflush="true"


### PR DESCRIPTION
I spent a lot of time trying to get the trace working, and it was because the application pool did not have write access to the program directory by default. There were no errors thrown to indicate this, just no trace file was written. This may be obvious to others, but it certainly wasn't for me.