### PR TITLE
fix broken link to Access token validation repo

### DIFF
--- a/docs/overview/packaging.md
+++ b/docs/overview/packaging.md
@@ -34,7 +34,7 @@ WS-Federation [nuget](https://www.nuget.org/packages/IdentityServer3.WsFederatio
 ### Access token validation middleware
 OWIN middleware for APIs. Provides an easy way to validate access tokens and enforce scope requirements.
 
-[nuget](https://www.nuget.org/packages/IdentityServer3.AccessTokenValidation/) | [github](https://github.com/identityserver/IdentityServer.v3.AccessTokenValidation)
+[nuget](https://www.nuget.org/packages/IdentityServer3.AccessTokenValidation/) | [github](https://github.com/IdentityServer/IdentityServer3.AccessTokenValidation)
 
 ## Dev builds
 


### PR DESCRIPTION
Fix the link to Access token validation middleware GitHub repo.