### PR TITLE
removed Thinktecture namespace from EF packages

### DIFF
--- a/docsv2/ef/migrations.md
+++ b/docsv2/ef/migrations.md
@@ -16,18 +16,18 @@ There are three different `DbContext`-derived classes contained in the EF implem
 * `ScopeConfigurationDbContext`
 * `OperationalDbContext`
 
-These will be needed since the database context classes are in a different assembly (i.e. `Thinktecture.IdentityServer3.EntityFramework`) than the hosting application.
+These will be needed since the database context classes are in a different assembly (i.e. `IdentityServer3.EntityFramework`) than the hosting application.
 
 ## Enabling migrations
 
 A migration must be created for each database context class. To enable migrations for all of the database context classes, the command below can be used from the the package manager console:
 
 ```
-Enable-Migrations -MigrationsDirectory Migrations\ClientConfiguration -ContextTypeName ClientConfigurationDbContext -ContextAssemblyName Thinktecture.IdentityServer3.EntityFramework -ConnectionStringName IdSvr3Config
+Enable-Migrations -MigrationsDirectory Migrations\ClientConfiguration -ContextTypeName ClientConfigurationDbContext -ContextAssemblyName IdentityServer3.EntityFramework -ConnectionStringName IdSvr3Config
 
-Enable-Migrations -MigrationsDirectory Migrations\ScopeConfiguration -ContextTypeName ScopeConfigurationDbContext -ContextAssemblyName Thinktecture.IdentityServer3.EntityFramework -ConnectionStringName IdSvr3Config
+Enable-Migrations -MigrationsDirectory Migrations\ScopeConfiguration -ContextTypeName ScopeConfigurationDbContext -ContextAssemblyName IdentityServer3.EntityFramework -ConnectionStringName IdSvr3Config
 
-Enable-Migrations -MigrationsDirectory Migrations\OperationalConfiguration -ContextTypeName OperationalDbContext -ContextAssemblyName Thinktecture.IdentityServer3.EntityFramework -ConnectionStringName IdSvr3Config
+Enable-Migrations -MigrationsDirectory Migrations\OperationalConfiguration -ContextTypeName OperationalDbContext -ContextAssemblyName IdentityServer3.EntityFramework -ConnectionStringName IdSvr3Config
 ```
 
 The the initial schema must then be defined (again one for each migration), as such:


### PR DESCRIPTION
Since "Thinktecture." has been removed in V2, I removed the prefix in this doc as well