### PR TITLE
Remove Trailing Comma from the List (Code Example)

### DIFF
--- a/docs/configuration/clients.md
+++ b/docs/configuration/clients.md
@@ -83,12 +83,12 @@ var client = new Client
 
     RedirectUris = new List<string>
     {
-        "https://myapp/callback.html",
+        "https://myapp/callback.html"
     },
 
     PostLogoutRedirectUris = new List<string>
     {
-        "http://localhost:23453/index.html",
+        "http://localhost:23453/index.html"
     }
 }
 ```


### PR DESCRIPTION
Removed trailing comma from RedirectUris and PostLogoutRedirectUris list.