### PR TITLE
Fix Typo in Header

### DIFF
--- a/docsv2/advanced/customServices.md
+++ b/docsv2/advanced/customServices.md
@@ -22,7 +22,7 @@ Three of the services are mandatory and must be configured by the implementer, t
 We provide a simple in-memory version of these three services as well as support for data stores via the related repos or community projects.
 See [here](../configuration/inMemory.html) for more details.
 
-##Registering custom Services
+## Registering custom Services
 
 You can replace every service and register additional custom ones. This is encapsulated by the `Registration` class.
 A `Registration` represents a way for IdentityServer to obtain an instance of your service.


### PR DESCRIPTION
Minor markdown typo, header now shows as h2