### PR TITLE
Missing "RequireSsl = false" prevents example working

### DIFF
--- a/docsv2/overview/simplestOAuth.md
+++ b/docsv2/overview/simplestOAuth.md
@@ -122,7 +122,9 @@ namespace IdSrv
                 Factory = new IdentityServerServiceFactory()
                             .UseInMemoryClients(Clients.Get())
                             .UseInMemoryScopes(Scopes.Get())
-                            .UseInMemoryUsers(new List<InMemoryUser>())
+                            .UseInMemoryUsers(new List<InMemoryUser>()),
+                            
+                RequireSsl = false
             };
 
             app.UseIdentityServer(options);


### PR DESCRIPTION
The example code that configures Identity Server for the walkthrough is missing the configuration option to not require SSL. As a result, the example fails to get a token because SSL is required. The completed sample source code includes "RequireSsl = false" in the configuration.