### PR TITLE
Update mvcGettingStarted.md to reflect screenshots

### DIFF
--- a/docsv2/overview/mvcGettingStarted.md
+++ b/docsv2/overview/mvcGettingStarted.md
@@ -45,6 +45,7 @@ public static class Clients
                 ClientName = "MVC Client",
                 ClientId = "mvc",
                 Flow = Flows.Implicit,
+                RequireConsent = false,
 
                 RedirectUris = new List<string>
                 {


### PR DESCRIPTION
Without RequireConsent = false, then the consent screen appears after the login screen.
As someone new to IdentityServer, this caused me a bit of confusion. I think it'd be clearer to either to remove it from the sample, or to screenshot the consent process and discuss turning it off.