### PR TITLE
Update JS walkthrough to use oidc-client-js

### DIFF
--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -562,27 +562,18 @@ Now that we have an access token, we can include the call to the API:
     </div>
 
     <div class="row">
-        <!-- Make the existing sections 4-column wide -->
-        <div class="col-xs-4">
+        <!-- Make the existing sections 6-column wide -->
+        <div class="col-xs-6">
             <div class="panel panel-default">
-                <div class="panel-heading">ID Token Contents</div>
+                <div class="panel-heading">User data</div>
                 <div class="panel-body">
-                    <pre class="js-id-token"></pre>
-                </div>
-            </div>
-        </div>
-
-        <div class="col-xs-4">
-            <div class="panel panel-default">
-                <div class="panel-heading">Access Token</div>
-                <div class="panel-body">
-                    <pre class="js-access-token"></pre>
+                    <pre class="js-user"></pre>
                 </div>
             </div>
         </div>
 
         <!-- And add a new one for the result of the API call -->
-        <div class="col-xs-4">
+        <div class="col-xs-6">
             <div class="panel panel-default">
                 <div class="panel-heading">API call result</div>
                 <div class="panel-body">
@@ -598,8 +589,8 @@ Now that we have an access token, we can include the call to the API:
 [...]
 $('.js-call-api').click(function () {
     var headers = {};
-    if (manager.access_token) {
-        headers['Authorization'] = 'Bearer ' + manager.access_token;
+    if (user && user.access_token) {
+        headers['Authorization'] = 'Bearer ' + user.access_token;
     }
 
     $.ajax({
@@ -609,7 +600,7 @@ $('.js-call-api').click(function () {
         headers: headers
     }).then(function (data) {
         display('.js-api-result', data);
-    }).fail(function (error) {
+    }).catch(function (error) {
         display('.js-api-result', {
             status: error.status,
             statusText: error.statusText,
@@ -624,11 +615,11 @@ Please note that the access token is passed in the `Authorization` header of the
 
 Here's what we see if we call the API prior to login:
 
-![api without access token](https://cloud.githubusercontent.com/assets/6102639/12254749/48aab0c6-b940-11e5-8842-83a526a5e316.png)
+![api-without-access-token](https://cloud.githubusercontent.com/assets/6102639/17660059/2ce58a44-631a-11e6-8f68-c7a4edf85074.PNG)
 
 And after login:
 
-![api with access token](https://cloud.githubusercontent.com/assets/6102639/12278299/6a3fe32a-b9d4-11e5-99b0-31805c502f5b.png)
+![api-with-access-token](https://cloud.githubusercontent.com/assets/6102639/17660060/2e898dfa-631a-11e6-9721-a0b98bd3fdcf.PNG)
 
 In the first case, there was no access token, hence no `Authorization` header in the request, so the access token validation middleware did nothing. The request flowed through the API as unauthenticated, the global `AuthorizeAttribute` rejected it and responded with a `401 Unauthorized` error.
 In the second case, the token validation middleware found the token in the `Authorization` header, passed it along to the introspection endpoint which flagged it as valid, and an identity was created with the claims it contained. The request, this time authenticated, flowed to Web API, the `AuthorizeAttribute` contrainsts were satisfied, and the endpoint was invoked.

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -785,7 +785,7 @@ But when the login popup opens, it could be that you still have a valid session 
 
 Logging out here means logging out of IdentityServer so that, next time you try to login from an IdentityServer-protected application, you will have to enter your credentials again.
 
-The process here is simple, we just need a logout button that calls the `redirectForLogout` method of the `OidcTokenManager` instance. We also need to let IdentityServer know that the specified post-logout redirect URL is valid:
+The process here is simple, we just need a logout button that calls the `signoutRedirect` method of the `UserManager` instance. We also need to let IdentityServer know that the specified post-logout redirect URL is valid:
 
 ```csharp
 public static class Clients
@@ -841,34 +841,40 @@ public static class Clients
 ```
 
 ```js
-[...]
 var settings = {
     authority: 'https://localhost:44300',
     client_id: 'js',
     popup_redirect_uri: 'http://localhost:56668/popup.html',
-
-    silent_renew: true,
     silent_redirect_uri: 'http://localhost:56668/silent-renew.html',
+    // Add the post logout redirect URL
+    post_logout_redirect_uri: 'http://localhost:56668/index.html',
 
     response_type: 'id_token token',
     scope: 'openid profile email api',
 
-    // post-logout URL
-    post_logout_redirect_uri: 'http://localhost:56668/index.html',
+    accessTokenExpiringNotificationTime: 4,
+    automaticSilentRenew: true,
 
-    filter_protocol_claims: true
+    filterProtocolClaims: true
 };
 [...]
-$('.js-logout').click(function () {
-    manager.redirectForLogout();
+$('.js-logout').on('click', function () {
+    manager
+        .signoutRedirect()
+        .catch(function (error) {
+            console.error('error while signing out user', error);
+        });
 });
 ```
 
 When clicking the `Logout` button, the user will be redirected to IdentityServer so that the session cookie is cleared.
 
-[logout](https://cloud.githubusercontent.com/assets/6102639/12256384/d9de8df0-b950-11e5-91b2-650a0a749a7f.png)
+![logout](https://cloud.githubusercontent.com/assets/6102639/12256384/d9de8df0-b950-11e5-91b2-650a0a749a7f.png)
 
 _Please note the screenshot above shows a page served by IdentityServer, not the JS application_
+
+While this example shows how to logout the user via the main window, it's worth noting that `oidc-client-js` also provides a way to make this happen in a popup, much like the login was implemented.
+You'll find more information in the [documentation of `oidc-client-js`](https://github.com/IdentityModel/oidc-client-js/wiki#methods).
 
 ## Check session
 

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -5,7 +5,7 @@ layout: docs-default
 This tutorial walks you through the necessary steps to integrate IdentityServer in a JS application.
 Since all the steps will be done on the client side, we'll use a JS library, [oidc-client-js](https://github.com/IdentityModel/oidc-client-js), to help with tasks like obtaining and validating tokens.
 
-**TODO: link to final code when in the Samples repo.**
+You can find the code associated with this walkthrough [in this repo](https://github.com/mderriey/IdentityServer.JsWalkthrough).
 
 The walkthrough is split in 3 parts:
 

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -461,14 +461,16 @@ Let's now add a basic endpoint to our API:
 [Route("values")]
 public class ValuesController : ApiController
 {
+    private static readonly Random _random = new Random();
+
     public IEnumerable<string> Get()
     {
         var random = new Random();
 
         return new[]
         {
-            random.Next(0, 10).ToString(),
-            random.Next(0, 10).ToString()
+            _random.Next(0, 10).ToString(),
+            _random.Next(0, 10).ToString()
         };
     }
 }

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -208,7 +208,7 @@ We also create a basic `index.html` file:
 <head>
     <title>JS Application</title>
     <meta charset="utf-8" />
-    <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css" />
+    <link rel="stylesheet" href="node_modules/bootstrap/dist/css/bootstrap.css" />
     <style>
         .main-container {
             padding-top: 70px;
@@ -250,9 +250,9 @@ We also create a basic `index.html` file:
         </div>
     </div>
 
-    <script src="bower_components/jquery/dist/jquery.js"></script>
-    <script src="bower_components/bootstrap/dist/js/bootstrap.js"></script>
-    <script src="bower_components/oidc-token-manager/dist/oidc-token-manager.js"></script>
+    <script src="node_modules/jquery/dist/jquery.js"></script>
+    <script src="node_modules/bootstrap/dist/js/bootstrap.js"></script>
+    <script src="node_modules/oidc-client/dist/oidc-client.js"></script>
 </body>
 </html>
 ```
@@ -267,12 +267,12 @@ and a `popup.html` file:
     <meta charset="utf-8" />
 </head>
 <body>
-    <script src="bower_components/oidc-token-manager/dist/oidc-token-manager.js"></script>
+    <script src="node_modules/oidc-client/dist/oidc-client.js"></script>
 </body>
 </html>
 ```
 
-We have two HTML files because `oidc-token-manager` can open a popup to show the login form to the user.
+We have two HTML files because `oidc-client` can open a popup to show the login form to the user.
 
 ## JS Client - authentication
 

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -310,7 +310,7 @@ manager.events.addUserLoaded(function (loadedUser) {
     display('.js-user', user);
 });
 
-$('.js-login').click(function () {
+$('.js-login').on('click', function () {
     manager
         .signinPopup()
         .catch(function (error) {
@@ -587,7 +587,7 @@ Now that we have an access token, we can include the call to the API:
 
 ```js
 [...]
-$('.js-call-api').click(function () {
+$('.js-call-api').on('click', function () {
     var headers = {};
     if (user && user.access_token) {
         headers['Authorization'] = 'Bearer ' + user.access_token;

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -2,8 +2,8 @@
 layout: docs-default
 ---
 
-This tutorial walks you through the necessary steps to integrate IdentityServer in a JS application.  
-Since all the steps will be done on the client side, we'll use a JS library, [oidc-token-manager](https://github.com/IdentityModel/oidc-token-manager), to help with tasks like getting and validating tokens.
+This tutorial walks you through the necessary steps to integrate IdentityServer in a JS application.
+Since all the steps will be done on the client side, we'll use a JS library, [oidc-client-js](https://github.com/IdentityModel/oidc-client-js), to help with tasks like obtaining and validating tokens.
 
 **TODO: link to final code when in the Samples repo.**
 
@@ -76,7 +76,7 @@ public static IEnumerable<Client> Get()
 }
 ```
 
-A special setting here is the `AllowedCorsOrigins` property. This allows IdentityServer to only accept browser-based requests from registered URLs.  
+A special setting here is the `AllowedCorsOrigins` property. This allows IdentityServer to only accept browser-based requests from registered URLs.
 More on the `popup.html` later on.
 
 **Remark** Right now the client has access to all scopes (via the `AllowAccessToAllScopes` setting). For production applications you would narrow that down to only the scopes it's expected to access with the `AllowedScopes` property.
@@ -320,7 +320,7 @@ Let's go quickly through the settings:
  - `scope` defines the scopes the application asks for
  - `filter_protocol_claims` instructs oidc-token-manager if it has to filter some OIDC protocol claims from the response: `nonce`, `at_hash`, `iat`, `nbf`, `exp`, `aud`, `iss` and `idp`
 
-We also handle clicks on the Login button to open the login page popup. The `openPopupForTokenAsync` returns a `Promise` which is resolved when the identity token has been retrieved and validated.  
+We also handle clicks on the Login button to open the login page popup. The `openPopupForTokenAsync` returns a `Promise` which is resolved when the identity token has been retrieved and validated.
 The whole token is accessible by the `id_token` property on the `OidcTokenManager` class. For practicality, the associated decoded payload is exposed via the `profile` property.
 
 We also have to configure `popup.html`:
@@ -488,7 +488,7 @@ public static class Scopes
 The new scope is a resource scope which means it will end up in the access token. Once again, we don't need to allow the client to request this new scope in this example because of the special setting, but it will be a necessary step in a real scenario.
 
 ## Updating the JS application
-We can now update the JS application settings so it will request the new `api` scope when logging in the user.  
+We can now update the JS application settings so it will request the new `api` scope when logging in the user.
 We had a section to show the identity token contents. Let's add another one where we'll see what the access token contains:
 
 ```html
@@ -702,13 +702,13 @@ public static class Clients
 }
 ```
 
-The access token lifetime, which is 1 hour by default, has been changed to 70 seconds.  
+The access token lifetime, which is 1 hour by default, has been changed to 70 seconds.
 What you'll experience if you login the JS application again is that you'll get the same `401 Unauthorized` error when you call the API 70 seconds after logging in.
 
 ## Renewing tokens
 
-We are going to rely on a feature `oidc-token-manager` gives us to renew the tokens.  
-The idea is that a dynamic `iframe` will be created on our page, which `oidc-token-manager` will use to issue a new authorization request while the user is still logged in. The [`prompt`](../endpoints/authorization.html) setting, set to `none`, is used to prevent the user from having to log in or give his consent while he has a valid session.  
+We are going to rely on a feature `oidc-token-manager` gives us to renew the tokens.
+The idea is that a dynamic `iframe` will be created on our page, which `oidc-token-manager` will use to issue a new authorization request while the user is still logged in. The [`prompt`](../endpoints/authorization.html) setting, set to `none`, is used to prevent the user from having to log in or give his consent while he has a valid session.
 IdentityServer will return a new access token which will replace the one stored in the `OidcTokenManager` instance.
 
 To achieve this, we have several steps to take.
@@ -750,8 +750,8 @@ var settings = {
 };
 ```
 
-The HTML file will be used in a dynamically created `iframe` to renew the token. The URL of that page is passed to the token manager settings to instruct it to automatically renew the token when it expires.  
-The token manager will renew the token 60 seconds before it expires, which explains why we chose to change to access token lifetime to 70 seconds.  
+The HTML file will be used in a dynamically created `iframe` to renew the token. The URL of that page is passed to the token manager settings to instruct it to automatically renew the token when it expires.
+The token manager will renew the token 60 seconds before it expires, which explains why we chose to change to access token lifetime to 70 seconds.
 This means the token will be renewed every 10 seconds.
 
 The second step is to let IdentityServer know that it is OK to redirect the user to it after the authentication is successful:
@@ -790,7 +790,7 @@ public static class Clients
 }
 ```
 
-The third and final step will allow to see the updated access token in the associated panel every time it's renewed.  
+The third and final step will allow to see the updated access token in the associated panel every time it's renewed.
 The `OidcTokenManager` exposes a `addOnTokenObtained` method which takes a callback as a parameter. This callback will be invoked every time an access token is obtained. This includes the first time the user logs in as well as whenever the token is silently renewed.
 
 ```js
@@ -813,11 +813,11 @@ $('.js-login').click(function () {
 });
 ```
 
-You can now see that the content of the access token section updates itself as the access token is renewed every 10 seconds. 
+You can now see that the content of the access token section updates itself as the access token is renewed every 10 seconds.
 
 ## Logging out
 
-Logging out of a JS application has a different meaning than from a server-side application, because if you refresh the main page, you will lose the tokens and will have to login again.  
+Logging out of a JS application has a different meaning than from a server-side application, because if you refresh the main page, you will lose the tokens and will have to login again.
 But when the login popup opens, it could be that you still have a valid session cookie for the IdentityServer web application. It could then be possible that the popup doesn't prompt you for your credentials and close itself. This is similar to when the token manager silently renews the token.
 
 Logging out here means logging out of IdentityServer so that, next time you try to login from an IdentityServer-protected application, you will have to enter your credentials again.

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -357,7 +357,7 @@ You can try and set the `filterProtocolClaims` property to `false` and see the a
 ## JS application - scopes
 
 Remember we configured our user with an `email` claim? It doesn't show up in the identity token because the scopes the client asked for - `openid` and `profile` - don't contain this claim.
-If you want to get the user's email, you'll have to ask for another scope which is called `email` by editing the `scopes` property of the `OidcTokenManager` settings.
+If you want to get the user's email, you'll have to ask for another scope which is called `email` by editing the `scopes` property of the `UserManager` settings.
 
 In our case, the only modification we need to make is to let IdentityServer know that this scope exists in the `Scopes` class:
 
@@ -379,9 +379,9 @@ public static class Scopes
 
 We don't have to change anything in the client configuration because we specified it has access to all the scopes. In a realistic scenario, you want to give a client access to only the scopes it's expected to request, so this would require a change in the client configuration as well.
 
-After this, we can see the `email` claim in the identity token:
+After this, we can see the `email` claim in the user profile:
 
-![login-email](https://cloud.githubusercontent.com/assets/6102639/12251318/25d3ce20-b922-11e5-9867-efc6afb76aea.png)
+![login-email](https://cloud.githubusercontent.com/assets/6102639/17659371/6a822c18-6315-11e6-9311-8bbf80e4bdc0.PNG)
 
 # Part 2 - API call
 In the second part, we'll see how you can call a protected API from the JS application.

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -46,33 +46,36 @@ Install-Package IdentityServer3 -ProjectName IdentityServer
 ````
 
 ## Configuring IdentityServer - Clients
-IdentityServer needs some information about the clients it is going to support, this can be simply supplied using a `Client` object:
+IdentityServer needs some information about the clients it is going to support, this can be easily achieved by supplying a collection of `Client` objects:
 
 ```csharp
-public static IEnumerable<Client> Get()
+public static class Clients
 {
-    return new[]
+    public static IEnumerable<Client> Get()
     {
-        new Client
+        return new[]
         {
-            Enabled = true,
-            ClientName = "JS Client",
-            ClientId = "js",
-            Flow = Flows.Implicit,
-
-            RedirectUris = new List<string>
+            new Client
             {
-                "http://localhost:56668/popup.html"
-            },
+                Enabled = true,
+                ClientName = "JS Client",
+                ClientId = "js",
+                Flow = Flows.Implicit,
 
-            AllowedCorsOrigins = new List<string>
-            {
-                "http://localhost:56668"
-            },
+                RedirectUris = new List<string>
+                {
+                    "http://localhost:56668/popup.html"
+                },
 
-            AllowAccessToAllScopes = true
-        }
-    };
+                AllowedCorsOrigins = new List<string>
+                {
+                    "http://localhost:56668"
+                },
+
+                AllowAccessToAllScopes = true
+            }
+        };
+    }
 }
 ```
 

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -134,7 +134,7 @@ IdentityServer is configured in the startup class. Here we provide information a
 the signing certificate and some other configuration options.
 In production you should load the signing certificate from the Windows certificate store or some other secured source.
 In this sample we simply added it to the project as a file (you can download a test certificate from [here](https://github.com/identityserver/Thinktecture.IdentityServer3.Samples/tree/master/source/Certificates).
-Add it to the project and set its build action to `Copy to output`.
+Add it to the project and set its `Copy to Output Directory` property to `Copy always`.
 
 
 For info on how to load the certificate from Azure WebSites see [here](http://azure.microsoft.com/blog/2014/10/27/using-certificates-in-azure-websites-applications/).

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -880,6 +880,7 @@ You'll find more information in the [documentation of `oidc-client-js`](https://
 
 The session in our JS application starts when the identity token we get back from IdentityServer is validated.
 IdentityServer itself supports session management so it returns, in the authorization response, a value named `session_state`.
+You can find the OpenID Connect spec related to that matter [here](http://openid.net/specs/openid-connect-session-1_0.html).
 
 In some cases, we might be interested to know if the user ended their session on IdentityServer, for example by logging out of another application which in turned logged them out of IdentityServer.
 The way to do this this is to compute the `session_state` value. If it's equal to the one IdentityServer sent, this means the session state is unchanged, so the user is still logged in. It it's different, something changed, possibly the user logged out. In this case it's advised to issue a silent authorization request, with `prompt=none`. If it succeeds, we get a new identity token, and it means the session on the IdentityServer side is still valid. If it fails, the user has logged out, and we have to ask them to log in again.

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -401,8 +401,17 @@ Install-Package Microsoft.Owin.Host.SystemWeb -ProjectName Api
 Install-Package Microsoft.Owin.Cors -ProjectName Api
 Install-Package Microsoft.AspNet.WebApi.Owin -ProjectName Api
 Install-Package IdentityServer3.AccessTokenValidation -ProjectName Api
+```
 
-Update-Package -ProjectName Api
+**Important** The `IdentityServer3.AccessTokenValidation` package has an indirect dependency on `System.IdentityModel.Tokens.Jwt`.
+At the time of writing, globally updating `Api` project NuGet packages brings down version `5.0.0` of `System.IdentityModel.Tokens.Jwt` which causes an error when starting the `Api` project:
+
+![api-update-microsoft-identity-tokens](https://cloud.githubusercontent.com/assets/6102639/17659609/119a6be0-6317-11e6-9ca1-24889b813463.PNG)
+
+The solution is to bring back an older compatible version of `System.IdentityModel.Tokens.Jwt`
+
+```
+Install-Package System.IdentityModel.Tokens.Jwt -ProjectName Api -Version 4.0.2.206221351
 ```
 
 Let's now create a `Startup` class and build our OWIN/Katana pipeline.

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -156,7 +156,7 @@ public class Startup
         });
     }
 
-    X509Certificate2 LoadCertificate()
+    private static X509Certificate2 LoadCertificate()
     {
         return new X509Certificate2(
             Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"bin\Config\idsrv3test.pfx"), "idsrv3test");

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -881,274 +881,91 @@ You'll find more information in the [documentation of `oidc-client-js`](https://
 The session in our JS application starts when the identity token we get back from IdentityServer is validated.
 IdentityServer itself supports session management so it returns, in the authorization response, a value named `session_state`.
 
-In some cases, we might be interested to know if the user ended his session on IdentityServer, for example by logging out of another application which in turned logged him out of IdentityServer.
-The idea is to compute again the `session_state` value. If it's equal to the one IdentityServer sent, this means the session state is unchanged, so the user is still logged in. It it's different, something changed, possibly the user logged out. In this case it's advised to issue a silent authorization request, with `prompt=none`. If it succeeds, we get a new identity token, and it means the session on the IdentityServer side is still valid. If it fails, the user has logged out, and we have to ask him to log in again.
+In some cases, we might be interested to know if the user ended their session on IdentityServer, for example by logging out of another application which in turned logged them out of IdentityServer.
+The way to do this this is to compute the `session_state` value. If it's equal to the one IdentityServer sent, this means the session state is unchanged, so the user is still logged in. It it's different, something changed, possibly the user logged out. In this case it's advised to issue a silent authorization request, with `prompt=none`. If it succeeds, we get a new identity token, and it means the session on the IdentityServer side is still valid. If it fails, the user has logged out, and we have to ask them to log in again.
 
 Unfortunately, the JS application on its own cannot compute the `session_state` value because it depends on the IdentityServer session cookie value which it doesn't have access to.
-The design of the [specification](https://openid.net/specs/openid-connect-session-1_0.html) requires to load, in a hidden `iframe`, the checksession endpoint from IdentityServer. The JS application and this `iframe` can then communicate with the [`postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) function.
+The design of the [specification](https://openid.net/specs/openid-connect-session-1_0.html) requires to load, in a hidden `iframe`, the checksession endpoint from IdentityServer. The JS application and this `iframe` can then communicate with the [`postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) API.
 
 ### The checksession endpoint
 
 This endpoint serves a simple page which listens to messages sent with `postMessage`. The data passed in the message is used to compute the session state hash. If it matches the one sent by IdentityServer, the page sends a message back to the calling window with the value `unchanged`. It it doesn't, it sends back `changed`. If something goes wrong, it sends `error`.
 
-### Prerequisites
+### Building the session check feature
 
-Before going further, we have to make a slight modification.
-If the checksession `iframe` - loaded from IdentityServer, thus over HTTPS - is loaded from a page served over HTTP, we will run into issues.
-The solution is to serve our JS application over HTTPS, too.
+Fortunately, `oidc-client-js` takes care of everything.
+As a matter of fact, the default settings monitor the session state already.
+The name of the associated property is [`monitorSession`](https://github.com/IdentityModel/oidc-client-js/wiki#usermanager).
 
-Here are the several steps to take:
+This means that right after the user is logged in, `oidc-client-js` creates a hidden `iframe` in which the sessioncheck endpoint from IdentityServer is loaded.
+At regular intervals, a message is sent to that `iframe` with both the client id and the session state.
+Messages sent to the `iframe` are also handled and the received value determines if a session change has happened.
 
-First, enable SSL for the `JsApplication` project, and change the URL in the project properties, as we did for the `IdentityServer` project:
+To acknowledge this works as expected, we'll take advantage of the logging system provided by `oidc-client-js`.
+By default, a no-op logger is used, but we can have the library log messages to the browser console.
 
-![idsrv app url](https://cloud.githubusercontent.com/assets/6102639/12341948/a1c58718-bb79-11e5-9b8d-701e20d029b7.png)
+```js
+Oidc.Log.logger = console;
+```
 
-Then, in the `Clients` class of the `IdentityServer` project, replace all the URLs with the new ones:
+To minimise the amount of logged messages, we'll also increase the access token lifetime.
+Lots of messages are logged when renewing tokens, and with the current settings this happens every 6 seconds.
+Let's increase the lifetime to 1 minute.
 
 ```csharp
 public static class Clients
 {
-    public static IEnumerable<Client> Get()
+public static IEnumerable<Client> Get()
+{
+    return new[]
     {
-        return new[]
+        new Client
         {
-            new Client
+            Enabled = true,
+            ClientName = "JS Client",
+            ClientId = "js",
+            Flow = Flows.Implicit,
+
+            RedirectUris = new List<string>
             {
-                Enabled = true,
-                ClientName = "JS Client",
-                ClientId = "js",
-                Flow = Flows.Implicit,
+                "http://localhost:56668/popup.html",
+                "http://localhost:56668/silent-renew.html"
+            },
 
-                RedirectUris = new List<string>
-                {
-                    "https://localhost:44301/popup.html",
-                    "https://localhost:44301/silent-renew.html"
-                },
+            PostLogoutRedirectUris = new List<string>
+            {
+                "http://localhost:56668/index.html"
+            },
 
-                PostLogoutRedirectUris = new List<string>
-                {
-                    "https://localhost:44301/index.html"
-                },
+            AllowedCorsOrigins = new List<string>
+            {
+                "http://localhost:56668"
+            },
 
-                AllowedCorsOrigins = new List<string>
-                {
-                    "https://localhost:44301"
-                },
-
-                AllowAccessToAllScopes = true,
-                AccessTokenLifetime = 70
-            }
-        };
-    }
+            AllowAccessToAllScopes = true,
+            // Access token lifetime increased to 1 minute
+            AccessTokenLifetime = 60
+        }
+    };
 }
 ```
 
-Also replace the URLs in the token manager settings in the `index.html` file of the JS application:
+Lastly, when a session change is detected and an automatic signin doesn't succeed, the `UserManager` raises a `userSignedOut` event.
+Let's add a handler to this event.
 
 ```js
-[...]
-var settings = {
-    authority: 'https://localhost:44300',
-    client_id: 'js',
-    popup_redirect_uri: 'https://localhost:44301/popup.html',
-
-    silent_renew: true,
-    silent_redirect_uri: 'https://localhost:44301/silent-renew.html',
-
-    response_type: 'id_token token',
-    scope: 'openid profile email api',
-
-    post_logout_redirect_uri: 'https://localhost:44301/index.html',
-
-    filter_protocol_claims: true
-};
-```
-
-Since you cannot access an HTTP resource from an HTTPS resource, we have to make the API available over HTTPS, too. Enable SSL as we did for the other projects, and update the URL in `index.html`:
-
-```js
-$('.js-call-api').click(function () {
-    var headers = {};
-    if (manager.access_token) {
-        headers['Authorization'] = 'Bearer ' + manager.access_token;
-    }
-
-    $.ajax({
-        url: 'https://localhost:44302/values',
-        method: 'GET',
-        dataType: 'json',
-        headers: headers
-    }).then(function (data) {
-        display('.js-api-result', data);
-    }).fail(function (error) {
-        display('.js-api-result', {
-            status: error.status,
-            statusText: error.statusText,
-            response: error.responseJSON
-        });
-    });
+manager.events.addUserSignedOut(function () {
+    alert('The user has signed out');
 });
 ```
 
-### Building the session check feature
+After navigating back to the application, logging out, opening the console, and logging back in, we can see in the console that every 2 seconds - the default interval - `oidc-client-js` checks for us
+that the session at IdentityServer is still valid
 
-Now, create a `check-session.html` file with the following contents:
+![session-check](https://cloud.githubusercontent.com/assets/6102639/17755020/e5fcc630-651a-11e6-8b4b-72b35d3d4f67.png)
 
-```html
-<!DOCTYPE html>
-<html>
-<head>
-    <title>RP Check Session IFrame</title>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-</head>
-<body>
-    <iframe id="op"></iframe>
-    <script>
-        if (window.location.hash) {
-            // 1 - getting parameters
-            var hash = window.location.hash.substr(1);
-            var params = hash.split('&').reduce(function (curr, item) {
-                var parts = item.split('=');
-                curr[parts[0].trim()] = parts[1].trim();
-                return curr;
-            }, {});
+To prove that it works, let's open a second tab, navigate to the JS application and login.
+Now both tabs check the state of the session with IdentityServer.
+Logout from one of the tab and observe the `userSignedOut` being handled and the popup appear.
 
-            // 2 - parameters check
-            if (!params.session_state) {
-                console.error('No session_state passed to RP session frame');
-            }
-            else if (!params.check_session_iframe) {
-                console.error('No check_session_iframe passed to RP session frame');
-            }
-            else if (!params.client_id) {
-                console.error('No client_id passed to RP session frame');
-            }
-            else {
-                var idSrvOrigin = 'https://localhost:44300';
-
-                var frame = document.getElementById('op');
-                frame.onload = function () {
-                    // 3 - posting messages
-                    var op = frame.contentWindow;
-                    var timer = window.setInterval(function () {
-                        op.postMessage(params.client_id + ' ' + params.session_state, idSrvOrigin);
-                    }, 2000);
-
-                    // 4 - receiving messages
-                    window.addEventListener('message', function (e) {
-                        if (e.origin === idSrvOrigin) {
-                            console.log('session state', e.data);
-                            if (e.data === 'changed' || e.data === 'error') {
-                                window.clearInterval(timer);
-                            }
-
-                            if (e.data === 'changed') {
-                                window.parent.postMessage('changed', 'https://localhost:44301');
-                            }
-                        }
-                    });
-                };
-
-                // 5 - loading the iframe
-                frame.src = params.check_session_iframe;
-            }
-        }
-    </script>
-</body>
-</html>
-```
-
-An important notion is to get that this page will be loaded by `index.html` in an `iframe`.
-As you can see, it itself contains an `iframe`, in which we'll load the checksession page from IdentityServer.
-In this section, we'll differentiate them by calling them JS application iframe and IdentityServer iframe.
-
-Now, let's go through the different parts:
-
-The first code block parses the parameters passed in the URL after the hash sign. They are structured as in a query string, that is `key=value`.
-The result is stored in the `params` variable.
-
-The second part makes sure all the expected parameters were provided. We need 3 of them:
-
- - The `session_state` returned by IdentityServer
- - The URL of the checksession endpoint so we know where to load the `iframe` from
- - The client id, which is needed by the checksession endpoint to compute the session state hash
-
-Part #3 will be executed when the checkssion `iframe` is loaded. The idea here is to poll the checksession `iframe` by regularly sending messages with the `postMessage` function.
-
-For each sent message, a response message will be received which is what the fourth part takes care of.
-As a security measure, we make sure the message comes from the IdentityServer iframe since potentially any window could send a message.
-If the value we get back from IdentityServer is `changed`, we pass the message through by sending a message to the `index.html` file.
-
-The fifth and final part loads the IdentityServer iframe.
-
-### Wiring it in `index.html`
-
-The only missing piece is now to integrate what we built in the main page:
-
-```html
-[...]
-<!-- Will be used to load check-session.html -->
-<iframe id="rp" style="display:none"></iframe>
-
-<script src="bower_components/jquery/dist/jquery.js"></script>
-<script src="bower_components/bootstrap/dist/js/bootstrap.js"></script>
-<script src="bower_components/oidc-token-manager/dist/oidc-token-manager.js"></script>
-```
-
-```js
-[...]
-function checkSessionState() {
-    manager.oidcClient.loadMetadataAsync().then(function (meta) {
-        if (meta.check_session_iframe && manager.session_state) {
-            document.getElementById('rp').src = 'check-session.html#' +
-                'session_state=' + manager.session_state +
-                '&check_session_iframe=' + meta.check_session_iframe +
-                '&client_id=' + settings.client_id;
-        }
-        else {
-            document.getElementById('rp').src = 'about:blank';
-        }
-    });
-
-    window.onmessage = function (e) {
-        if (e.origin === 'https://localhost:44301' && e.data === 'changed') {
-            manager.removeToken();
-            manager.renewTokenSilentAsync().then(function () {
-                // Session state changed but we managed to silently get a new identity token, everything's fine
-                console.log('renewTokenSilentAsync success');
-            }, function () {
-                // Here we couldn't get a new identity token, we have to ask the user to log in again
-                console.log('renewTokenSilentAsync failed');
-            });
-        }
-    }
-}
-[...]
-$('.js-login').click(function () {
-    manager.openPopupForTokenAsync()
-        .then(function () {
-            display('.js-id-token', manager.profile);
-
-            // Load the iframe and start listening to messages
-            checkSessionState();
-
-            // Removed
-            // display('.js-access-token', { access_token: manager.access_token, expires_in: manager.expires_in });
-        }, function (error) {
-            console.error(error);
-        });
-});
-```
-
-When we initially get a token back from IdentityServer, we now call the `checkSessionState` function.
-It requests IdentityServer metadata endpoint to make sure the checksession endpoint is available since it could have been disabled.
-If it is, the `check-session.html` is loaded in a hidden `iframe`, passing along the parameters it needs.
-A listener for messages is then created. Here again, we want to make sure they come from the `check-session.html` page.
-
-As discussed earlier, in the case where the session state has changed, a silent authorization request is sent.
-If it succeeds, it means the session on IdentityServer is still valid and we got a new identity token.
-If it fails, the user must have logged out, so we have to ask him to log in again.
-
-We can simulate that by opening two tabs to the `index.html` file, logging in both of them. Inspecting `manager.session_state` in the console will give the same value.
-If we log out from one tab, we are redirected to IdentityServer where the session cookie will be cleared. Next time the session state is computed in the IdentityServer iframe of the other tab,
-it will detect that it has changed.
+![logout-event](https://cloud.githubusercontent.com/assets/6102639/17755105/5f317a64-651b-11e6-8c5b-1a2a7cc2b61c.png)

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -660,15 +660,15 @@ public static class Clients
                 },
 
                 AllowAccessToAllScopes = true,
-                AccessTokenLifetime = 70
+                AccessTokenLifetime = 10
             }
         };
     }
 }
 ```
 
-The access token lifetime, which is 1 hour by default, has been changed to 70 seconds.
-What you'll experience if you login the JS application again is that you'll get the same `401 Unauthorized` error when you call the API 70 seconds after logging in.
+The access token lifetime, which is 1 hour by default, has been changed to 10 seconds.
+What you'll experience if you login the JS application again is that you'll get the same `401 Unauthorized` error when you call the API 10 seconds after logging in.
 
 ## Renewing tokens
 

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -184,21 +184,21 @@ We use several third-party libraries to support our application:
 
  - [jQuery](http://jquery.com)
  - [Bootstrap](http://getbootstrap.com)
- - [oidc-token-manager](https://github.com/IdentityModel/oidc-token-manager)
+ - [oidc-client-js](https://github.com/IdentityModel/oidc-client-js)
 
-We are going to install them with [Bower](http://bower.io/), a front-end package manager. If you don't have Bower installed, you can follow [these instructions on the Bower website](http://bower.io/#install-bower).
-Once Bower is installed, open a command-line prompt in the `JsApplication` folder:
+We are going to install them with [npm](https://www.npmjs.com/), the Node.js front-end package manager. If you don't have npm installed, you can follow [these instructions on the npm website](https://docs.npmjs.com/getting-started/installing-node).
+Once npm is installed, open a command-line prompt in the `JsApplication` folder:
 
 ```sh
-$ bower install --save-dev jquery
-$ bower install --save-dev bootstrap
-$ bower install --save-dev oidc-token-manager
+$ npm install jquery
+$ npm install bootstrap
+$ npm install oidc-client
 ```
 
-By default, Bower installs packages in the `bower_components` folder.
+By default, npm installs packages in the `node_modules` folder.
 
-**Important** Bower packages are usually not committed to source control. If you cloned the repository containing the final source code and want to restore the Bower packages, open a
-command-line prompt in the `JsApplication` folder and run `bower install` to restore packages.
+**Important** npm packages are usually not committed to source control. If you cloned the repository containing the final source code and want to restore the npm packages, open a
+command-line prompt in the `JsApplication` folder and run `npm install` to restore packages.
 
 We also create a basic `index.html` file:
 

--- a/docsv2/overview/jsGettingStarted.md
+++ b/docsv2/overview/jsGettingStarted.md
@@ -514,71 +514,20 @@ The new scope is a resource scope which means it will end up in the access token
 
 ## Updating the JS application
 We can now update the JS application settings so it will request the new `api` scope when logging in the user.
-We had a section to show the identity token contents. Let's add another one where we'll see what the access token contains:
 
-```html
-[...]
-<div class="container main-container">
-    <div class="row">
-        <div class="col-xs-12">
-            <ul class="list-inline list-unstyled requests">
-                <li><a href="index.html" class="btn btn-primary">Home</a></li>
-                <li><button type="button" class="btn btn-default js-login">Login</button></li>
-            </ul>
-        </div>
-    </div>
+```js
+var settings = {
+    authority: 'https://localhost:44300',
+    client_id: 'js',
+    popup_redirect_uri: 'http://localhost:56668/popup.html',
 
-    <div class="row">
-        <!-- Make this panel 6-column wide -->
-        <div class="col-xs-6">
-            <div class="panel panel-default">
-                <div class="panel-heading">ID Token Contents</div>
-                <div class="panel-body">
-                    <pre class="js-id-token"></pre>
-                </div>
-            </div>
-        </div>
+    // We add `token` to specify we expect an access token too
+    response_type: 'id_token token',
+    // We add the new `api` scope to the list of requested scopes
+    scope: 'openid profile email api',
 
-        <!-- and create this new one for the access token -->
-        <div class="col-xs-6">
-            <div class="panel panel-default">
-                <div class="panel-heading">Access Token</div>
-                <div class="panel-body">
-                    <pre class="js-access-token"></pre>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
-[...]
-<script>
-    var settings = {
-        authority: 'https://localhost:44300',
-        client_id: 'js',
-        popup_redirect_uri: 'http://localhost:56668/popup.html',
-
-        // We add `token` to specify we expect an access token too
-        response_type: 'id_token token',
-        // We add the new `api` scope to the list of requested scopes
-        scope: 'openid profile email api',
-
-        filter_protocol_claims: true
-    };
-
-    var manager = new OidcTokenManager(settings);
-
-    $('.js-login').click(function () {
-        manager.openPopupForTokenAsync()
-            .then(function () {
-                display('.js-id-token', manager.profile);
-
-                // Display the access token and its expiration in the new section
-                display('.js-access-token', { access_token: manager.access_token, expires_in: manager.expires_in });
-            }, function (error) {
-                console.error(error);
-            });
-    });
-</script>
+    filterProtocolClaims: true
+};
 ```
 
 The modifications include:
@@ -587,12 +536,12 @@ The modifications include:
  - an updated `response_type` to specify we want an access token back along with the identity token
  - the new `api` scope to be requested as part of the login request
 
-The access token is exposed via the `access_token` property and its expiration via the `expires_in` property.
-It is worth noting that `oidc-token-manager` takes away a lot of pain by taking care of validating the tokens with the signing certificate, we don't have to write code.
+The access token is exposed via the `access_token` property and its expiration via the `expires_at` property.
+It is worth noting that `oidc-client` takes away a lot of pain by taking care of validating the tokens with the signing certificate, we don't have to write code.
 
 After logging in, here's what we get:
 
-![access token](https://cloud.githubusercontent.com/assets/6102639/12253628/1bc4e550-b935-11e5-95e9-fca21057cd08.png)
+![access-token](https://cloud.githubusercontent.com/assets/6102639/17659923/1ebf7a16-6319-11e6-99f7-33bef104d0e7.PNG)
 
 ## Calling the API
 


### PR DESCRIPTION
Hi,

Here's my first attempt at migrating the JS walkthrough to use [`oidc-client-js`](https://github.com/IdentityModel/oidc-client-js).

I linked to my personal repository where I keep the associated code. Please let me know if you want that somewhere else and I'll update the link.

As always, any comments/feedback would be much appreciated.

Thanks!