### PR TITLE
Updated IdentityServerOptions link to docsv2

### DIFF
--- a/docsv2/configuration/serviceFactory.md
+++ b/docsv2/configuration/serviceFactory.md
@@ -6,7 +6,7 @@ layout: docs-default
 
 IdentityServer3 contains many features for implementing OpenID Connect and OAuth2. Many of these features have been designed so they can be replaced. This would be useful for the scenarios where the default logic doesn’t match the hosting application’s requirements, or simply the application wishes to provide an entirely different implementation. And in fact, there are some extensibility points within IdentityServer3 that are required to be provided by the hosting application (such as the storage for configuration data or the identity management implementation for validating users’ credentials).
 
-The `IdentityServer3.Core.Configuration.IdentityServerServiceFactory` holds all these building blocks and must be supplied at startup time using the `IdentityServerOptions` class (see [here](http://identityserver.github.io/Documentation/docs/configuration/identityServerOptions.html) for more information on configuration options).
+The `IdentityServer3.Core.Configuration.IdentityServerServiceFactory` holds all these building blocks and must be supplied at startup time using the `IdentityServerOptions` class (see [here](http://identityserver.github.io/Documentation/docsv2/configuration/identityServerOptions.html) for more information on configuration options).
 
 The extensibility points fall into three categories.
 


### PR DESCRIPTION
Updated the broken link to the IdentityServerOptions page from the /docs/ path to /docsv2/