### PR TITLE
Update link for "Azure Table Storage Support"

### DIFF
--- a/docsv2/resources/community.md
+++ b/docsv2/resources/community.md
@@ -15,5 +15,5 @@ layout: docs-default
 * [Entity Framework 7 support (from 20 20)](https://github.com/2020IP/TwentyTwenty.IdentityServer3.EntityFramework7)
 * [Support for SAML2Bearer Assertions](https://www.nuget.org/packages/IdentityServer3.Contrib.Saml2Bearer/)
 * [Neo4j Support](https://github.com/edgecastle/IdentityServer3Neo4j/)
-* [Azure Table Storage Support](http://kylesonaty.com/identity-server-3-azure-table-storage-stores/)
+* [Azure Table Storage Support](https://github.com/kylesonaty/IdentityServer3.Contrib.Store.AzureTableStorage)
 * [XML-backed configuration for IdentityServer3, IdentityManager, and ASP.Net Identity](https://github.com/LinqBeast/IdentityServer3.Contrib.Configuration/)


### PR DESCRIPTION
The blog post referenced here is outdated and returning a 404. I have amended this item to point to the project's repository on GitHub.