### PR TITLE
Clarify that only the first library is used

### DIFF
--- a/docsv2/configuration/logging.md
+++ b/docsv2/configuration/logging.md
@@ -20,6 +20,8 @@ Liblog picks up any of the following logging libraries automatically:
 
 There is no IdentityServer3 specific configuration required - you just need to configure one of the above logging frameworks in your host.
 
+*Warning: LibLog will pick the first library in the above order and will discard the others. So if you have a reference to SeriLog for example and you're trying to configure Log4net it will **not** work.*
+
 ## Configuring Diagnostics
 The `LoggingOptions` class has the following settings:
 


### PR DESCRIPTION
It is important to know that LibLog will pick only the first library. I did spend a lot of time to setup log4net which I use and it wasn't working because the project had a reference to Serilog which I wasn't using.