### PR TITLE
More detail on how to hook up the InMemoryUserList

### DIFF
--- a/docsv2/overview/simplestOAuth.md
+++ b/docsv2/overview/simplestOAuth.md
@@ -322,6 +322,32 @@ the `Subject` is the unique identifier for that user that will be embedded into 
 
 In `Startup` replace the empty user list with a call to the `Get` method.
 
+```csharp
+using Owin;
+using IdentityServer3.Core.Configuration;
+
+namespace IdSrv
+{
+    class Startup
+    {
+        public void Configuration(IAppBuilder app)
+        {
+            var options = new IdentityServerOptions
+            {
+                Factory = new IdentityServerServiceFactory()
+                            .UseInMemoryClients(Clients.Get())
+                            .UseInMemoryScopes(Scopes.Get())
+                            .UseInMemoryUsers(Users.Get()),
+
+                RequireSsl = false
+            };
+
+            app.UseIdentityServer(options);
+        }
+    }
+}
+```
+
 ### Adding a Client
 Next we will add a client definition that uses the flow called `resource owner password credential grant`.
 This flow allows a client to send the user's username and password to the token service and get an access token back in return.


### PR DESCRIPTION
I had an issue where I couldn't figure out how to hook up the InMemoryUserList to IdentityServer and I kept reading over line 323 ("In Startup replace the empty user list with a call to the Get method.") without realizing that line 323 was the step that I was missing.  I think this code (or maybe even a smaller snippet of my code) should be added in to prevent people from accidentally skipping over the step.